### PR TITLE
Highlighting what is originalRecords in the ouput (only affecting json Output)

### DIFF
--- a/pkg/zonecompare/zonecompare.go
+++ b/pkg/zonecompare/zonecompare.go
@@ -341,13 +341,19 @@ func logAndReport(status string,
 	case "found", "notfound":
 		{
 			logPrint(options, options.Labelorigin, status, flattenDnsEntrySlice(entrySliceOrigin))
-			jzoneDiffSlice = append(jzoneDiffSlice, jzoneDiff{"status": status, options.Labelorigin: sliceStringOrigin})
+			jzoneDiffSlice = append(jzoneDiffSlice,
+				jzoneDiff{
+					"status": status,
+					"originalRecords": map[string][]string{
+						options.Labelorigin: sliceStringOrigin}})
 		}
 	case "different":
 		{
 			_jzoneDiff := jzoneDiff{"status": status,
-				options.Labelorigin:      sliceStringOrigin,
-				options.Labeldestination: sliceStringDestination}
+				"originalRecords": map[string][]string{
+					options.Labelorigin:      sliceStringOrigin,
+					options.Labeldestination: sliceStringDestination},
+			}
 			if _, found := deep[strings.ToLower(curType)]; found || options.DeepAll {
 				_differences := make(map[string][]string)
 				_repeats := make(map[string][]string)


### PR DESCRIPTION
## Before

```
{
  "host1-cpus.example.com.": {
    "TXT": [
      {
        "differences": {
          "examples/zone1": [
            "host1-cpus.example.com. 3600 IN TXT  cpu1 cpu2 cpu3",
            "host1-cpus.example.com. 3600 IN TXT  cpu6 cpu4 cpu5"
          ],
          "examples/zone2": [
            "host1-cpus.example.com. 3600 IN TXT  cpu6 cpu5 cpu3 cpu4 cpu1 cpu2"
          ]
        },
        "examples/zone1": [
          "host1-cpus.example.com. 3600 IN TXT  cpu1 cpu2 cpu3",
          "host1-cpus.example.com. 3600 IN TXT  cpu6 cpu4 cpu5"
        ],
        "examples/zone2": [
          "host1-cpus.example.com. 3600 IN TXT  cpu6 cpu5 cpu3 cpu4 cpu1 cpu2"
        ],
        "status": "different"
      }
    ]
  }
}
```

## After
```
{
  "host1-cpus.example.com.": {
    "TXT": [
      {
        "differences": {
          "examples/zone1": [
            "host1-cpus.example.com. 3600 IN TXT  cpu1 cpu2 cpu3",
            "host1-cpus.example.com. 3600 IN TXT  cpu6 cpu4 cpu5"
          ],
          "examples/zone2": [
            "host1-cpus.example.com. 3600 IN TXT  cpu6 cpu5 cpu3 cpu4 cpu1 cpu2"
          ]
        },
        "originalRecords": {
          "examples/zone1": [
            "host1-cpus.example.com. 3600 IN TXT  cpu1 cpu2 cpu3",
            "host1-cpus.example.com. 3600 IN TXT  cpu6 cpu4 cpu5"
          ],
          "examples/zone2": [
            "host1-cpus.example.com. 3600 IN TXT  cpu6 cpu5 cpu3 cpu4 cpu1 cpu2"
          ]
        },
        "status": "different"
      }
    ]
  }
}
```